### PR TITLE
fix(template): re-render template-driven styles after WS result lands

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -59,7 +59,7 @@ export function subscribeTemplate(this: PaperButtonsRow, config, object, key) {
       null,
       (res) => {
         object[key] = res;
-        this.requestUpdate();
+        this.requestUpdate("_config", null);
       },
       {
         template: option,


### PR DESCRIPTION
## Summary

When a Jinja-template style (e.g. `styles.icon.color`) on a button is driven by an entity attribute, the rendered DOM lags **one state-change behind** reality whenever multiple entity changes arrive close together (typical with Home Assistant scene activations, automations that touch several entities, or a rapid sequence of service calls).

The visible symptom: any template-driven style holds the value computed for the *previous* state until the *next* state-change rolls in. The DOM is permanently one step behind reality.

This PR is a **single-line fix in `src/template.ts`** that makes the template-result callback issue a property-keyed update rather than an unkeyed one. No public API changes. No new fields, no new methods.

## Reproduction

Configure any button-row in a Lovelace dashboard with an entity-driven Jinja template in a style field. Minimal example:

```yaml
type: entities
entities:
  - entity: light.example
    type: custom:secondaryinfo-entity-row
    extend_paper_buttons_row:
      buttons:
        - entity: light.example
          icon: mdi:lightbulb-on-20
          tap_action:
            action: call-service
            service: light.turn_on
            service_data:
              brightness_pct: 25
            target:
              entity_id: light.example
          styles:
            icon:
              color: >-
                {% set b = state_attr('light.example', 'brightness') %}
                {% if b and b >= 1 and b <= 69 %}
                  red
                {% else %}
                  grey
                {% endif %}
```

The simplest deterministic trigger is any service call that changes several entities at once — Home Assistant dispatches them concurrently, producing a burst of `state_changed` events for the tracked entity. Example:

```yaml
action: light.turn_on
target:
  entity_id:
    - light.example
    - light.example_2
    - light.example_3
data:
  brightness: 64
```

Any of the following will also reproduce it: HA scene activations, automations that update multiple entities, scripts firing several `call_service` steps in quick succession, or a network reconnect causing batched state replay. Refreshing the page resyncs the DOM in every case.

The bug is most obvious when the template's result *changes* between consecutive states (e.g. red → grey → red). Direct single-entity `light.turn_on` service calls usually do not trigger it, because a single state change finishes within the same microtask as the render and the WS template result lands before the render commits.

## Root cause

`subscribeTemplate` (in `src/template.ts`) registers a render-template subscription via card-tools. Its callback writes the new value into `object[key]` and calls `this.requestUpdate()` with no arguments:

```ts
(res) => {
  object[key] = res;
  this.requestUpdate();
}
```

`requestUpdate()` with no args produces an empty `changedProperties` map. Lit batches that pending update with the next property-driven update — almost always the next `hass` setter call. When the merged update finally runs, `shouldUpdate(changedProperties)` is invoked with `keys = ["hass"]`, and the existing `_entities.some(oldHass.states[entity] !== this.hass.states[entity])` comparison rejects the update because the most recent `hass` push usually has the *same* state-object reference for the tracked entity (HA dedupes — only entities that actually changed get fresh state objects, and the entity in question may have been included in an earlier push that already triggered the comparison).

So: the `object[key] = res` mutation lands, but no render fires. The next state-change's render then reads the value computed during the *previous* template push.

## Fix

Pass `_config` and a non-equal old value to `requestUpdate`. Lit's `_$changeProperty` runs `notEqual(this._config, null)` → true → marks `_config` as changed. `shouldUpdate`'s existing `if (changedProps.has("_config")) return true;` branch fires immediately. Render runs synchronously after the mutation lands.

### Diff

```diff
--- a/src/template.ts
+++ b/src/template.ts
@@ -59,7 +59,7 @@ export function subscribeTemplate(this: PaperButtonsRow, config, object, key) {
       null,
       (res) => {
         object[key] = res;
-        this.requestUpdate();
+        this.requestUpdate("_config", null);
       },
       {
         template: option,
```

One line. No other changes anywhere in the codebase.

## Verification

The card was deployed live against a Home Assistant instance with five paper-buttons-row instances on a single dashboard, each with four Jinja-template-driven `styles.icon.color` values. A scripted probe activated six bursts of state changes in sequence, covering every transition the templates needed to handle, and asserted the icon colour matched the *current* state at every step.

| | Before this PR | After this PR |
|---|---|---|
| Single-entity service call | ✓ correct | ✓ correct |
| Multi-entity service call (burst) | ❌ one step behind every time | ✓ correct |
| Repeated bursts | ❌ persistent lag | ✓ correct |

Direct single-entity service-call paths continue to work identically. No regressions observed.

## Out of scope

Several pre-existing patterns in the card (template subscriptions are never unsubscribed; `entity-row.ts` permanently patches `hui-generic-entity-row.prototype.firstUpdated`; `setConfig` mutates `this._config.buttons` after the property assignment, etc.) were noticed during the diagnosis but are deliberately not touched here to keep the diff surgical. Happy to open follow-up issues if any are of interest.
